### PR TITLE
Create interaction hit/hurtboxes and player signals

### DIFF
--- a/Player.gd
+++ b/Player.gd
@@ -8,77 +8,97 @@ const FRICTION = 800
 const JUMP_VELOCITY = -200
 
 enum {
-	MOVE,
-	ROLL,
-	ATTACK
+    MOVE,
+    ROLL,
+    ATTACK
 }
 
 var state = MOVE
 var velocity = Vector2.ZERO
+var interactable = null
 
 onready var animationPlayer = $AnimationPlayer
 #onready var animationTree = $AnimationTree
 #onready var animationState = animationTree.get("parameters/playback")
-	
-	
+ 
+signal player_can_interact(area)
+signal player_interacted(area)
+    
 func _process(delta):
-	var input_vector = Vector2.ZERO
-	input_vector.x = Input.get_action_strength("move_right") - Input.get_action_strength("move_left")
-	input_vector = input_vector.normalized()
-	if input_vector != Vector2.ZERO:
-		#animationTree.set("parameters/Idle/blend_position", input_vector)
-		#animationTree.set("parameters/Run/blend_position", input_vector)
-		#animationTree.set("parameters/Attack/blend_position", input_vector)
-		#animationState.travel("Run")
-		velocity.x = velocity.move_toward(input_vector * MAX_SPEED, ACCELERATION * delta).x
-	else:
-		#animationState.travel("Idle")
-		velocity.x = 0
-		velocity = velocity.move_toward(velocity, FRICTION * delta)
-		
-	#TODO: make sure jump action can only be performed on ground, or if double jump is enabled
-	if Input.is_action_just_pressed("jump"):
-		velocity.y = JUMP_VELOCITY
-	velocity = move_and_slide(velocity)
-	
-	
-	"""match state:
-		MOVE:
-			move_state(delta)
-		ROLL:
-			pass
-		ATTACK:
-			attack_state(delta)"""
-	
+    var input_vector = Vector2.ZERO
+    input_vector.x = Input.get_action_strength("move_right") - Input.get_action_strength("move_left")
+    input_vector = input_vector.normalized()
+    if input_vector != Vector2.ZERO:
+        #animationTree.set("parameters/Idle/blend_position", input_vector)
+        #animationTree.set("parameters/Run/blend_position", input_vector)
+        #animationTree.set("parameters/Attack/blend_position", input_vector)
+        #animationState.travel("Run")
+        velocity.x = velocity.move_toward(input_vector * MAX_SPEED, ACCELERATION * delta).x
+    else:
+        #animationState.travel("Idle")
+        velocity.x = 0
+        velocity = velocity.move_toward(velocity, FRICTION * delta)
+        
+    #TODO: make sure jump action can only be performed on ground, or if double jump is enabled
+    if Input.is_action_just_pressed("jump"):
+        velocity.y = JUMP_VELOCITY
+    velocity = move_and_slide(velocity)
+    
+    if Input.is_action_just_pressed("interact") and interactable != null:
+        print("Interacted with %s" % interactable.name)
+        emit_signal("player_interacted", interactable)
+    
+    
+    """match state:
+        MOVE:
+            move_state(delta)
+        ROLL:
+            pass
+        ATTACK:
+            attack_state(delta)"""
+    
 func _physics_process(delta):
-	velocity.y += delta * GRAVITY
-	#move_and_collide(motion)	
-	
-		
+    velocity.y += delta * GRAVITY
+    #move_and_collide(motion)	
+    
+        
 func move_state(delta):
-	var input_vector = Vector2.ZERO
-	input_vector.x = Input.get_action_strength("move_right") - Input.get_action_strength("move_left")
-	#print(input_vector.x)
-	#input_vector.y = Input.get_action_strength("ui_down") - Input.get_action_strength("ui_up")
-	input_vector = input_vector.normalized()
-	if input_vector != Vector2.ZERO:
-		#animationTree.set("parameters/Idle/blend_position", input_vector)
-		#animationTree.set("parameters/Run/blend_position", input_vector)
-		#animationTree.set("parameters/Attack/blend_position", input_vector)
-		#animationState.travel("Run")
-		velocity = velocity.move_toward(input_vector * MAX_SPEED, ACCELERATION * delta)
-	else:
-		#animationState.travel("Idle")
-		velocity = velocity.move_toward(Vector2.ZERO, FRICTION * delta)
-		
-	velocity = move_and_slide(velocity)
-	
-	if Input.is_action_just_pressed("attack"):
-		state = ATTACK
-	
+    var input_vector = Vector2.ZERO
+    input_vector.x = Input.get_action_strength("move_right") - Input.get_action_strength("move_left")
+    #print(input_vector.x)
+    #input_vector.y = Input.get_action_strength("ui_down") - Input.get_action_strength("ui_up")
+    input_vector = input_vector.normalized()
+    if input_vector != Vector2.ZERO:
+        #animationTree.set("parameters/Idle/blend_position", input_vector)
+        #animationTree.set("parameters/Run/blend_position", input_vector)
+        #animationTree.set("parameters/Attack/blend_position", input_vector)
+        #animationState.travel("Run")
+        velocity = velocity.move_toward(input_vector * MAX_SPEED, ACCELERATION * delta)
+    else:
+        #animationState.travel("Idle")
+        velocity = velocity.move_toward(Vector2.ZERO, FRICTION * delta)
+        
+    velocity = move_and_slide(velocity)
+    
+    if Input.is_action_just_pressed("attack"):
+        state = ATTACK
+    
 func attack_state(delta):
-	velocity = Vector2.ZERO
-	#animationState.travel("Attack")
-	
+    velocity = Vector2.ZERO
+    #animationState.travel("Attack")
+    
 func attack_animation_finished():
-	state = MOVE
+    state = MOVE
+
+func _on_InteractHitbox_area_entered(area):
+    var node = area.get_owner()
+    print("Collided with %s" % node.name)
+    interactable = node
+    emit_signal("player_can_interact", interactable)
+
+
+func _on_InteractHitbox_area_exited(area):
+    var node = area.get_owner()
+    print("Stopped colliding with %s" % area.name)
+    if (area.name == interactable.name): 
+        interactable = null

--- a/Player/Player.tscn
+++ b/Player/Player.tscn
@@ -1,11 +1,15 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://Player.gd" type="Script" id=1]
 [ext_resource path="res://Temp Assets/AdventurerAnimations/Adventurer/adventurer-Sheet.png" type="Texture" id=2]
+[ext_resource path="res://Systems/InteractHitbox.tscn" type="PackedScene" id=3]
 
 [sub_resource type="CapsuleShape2D" id=2]
 radius = 4.0
 height = 4.0
+
+[sub_resource type="RectangleShape2D" id=3]
+extents = Vector2( 12.0001, 20.5 )
 
 [node name="Player" type="KinematicBody2D"]
 script = ExtResource( 1 )
@@ -22,4 +26,17 @@ position = Vector2( 0, -3.5 )
 rotation = 1.5708
 shape = SubResource( 2 )
 
+[node name="InteractHitbox" parent="." instance=ExtResource( 3 )]
+position = Vector2( 0, -3.5 )
+rotation = 1.5708
+
+[node name="CollisionShape2D" parent="InteractHitbox" index="0"]
+position = Vector2( -8.50006, -10.4999 )
+shape = SubResource( 3 )
+
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+
+[connection signal="area_entered" from="InteractHitbox" to="." method="_on_InteractHitbox_area_entered"]
+[connection signal="area_exited" from="InteractHitbox" to="." method="_on_InteractHitbox_area_exited"]
+
+[editable path="InteractHitbox"]

--- a/Systems/InteractHitbox.tscn
+++ b/Systems/InteractHitbox.tscn
@@ -1,0 +1,7 @@
+[gd_scene format=2]
+
+[node name="InteractHitbox" type="Area2D"]
+collision_layer = 0
+collision_mask = 256
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]

--- a/Systems/InteractHurtbox.tscn
+++ b/Systems/InteractHurtbox.tscn
@@ -1,0 +1,7 @@
+[gd_scene format=2]
+
+[node name="InteractHurtbox" type="Area2D"]
+collision_layer = 256
+collision_mask = 0
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]

--- a/project.godot
+++ b/project.godot
@@ -79,6 +79,20 @@ jump={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777232,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
+interact={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":69,"unicode":0,"echo":false,"script":null)
+ ]
+}
+
+[layer_names]
+
+2d_render/layer_1="Player"
+2d_render/layer_9="Interactable"
+2d_physics/layer_1="Player"
+2d_physics/layer_9="Interactable"
+2d_navigation/layer_1="Player"
+2d_navigation/layer_9="Interactable"
 
 [physics]
 


### PR DESCRIPTION
Created an interaction hit and hurtbox combo.

The player now has a interaction hitbox that extends a little in front of it:
![image](https://user-images.githubusercontent.com/8145874/218343794-8f009fec-6b57-461e-bb4b-335650454a2d.png)

You can attach an interaction hurtbox to interactables in the world. This will allow them to be seen by the interaction hitbox and will allow the player to send an `player_interacted` signal when the player presses E within bounds.

![image](https://user-images.githubusercontent.com/8145874/218343884-14c33f31-c4bf-4665-80a2-b90d17097491.png)

Planning on having the UI system listen to the `player_interacted` signal and show an appropriate dialog depending on the interacted item.